### PR TITLE
Formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Supported output formats (audio only):
 * OGG
 
 Additional output formats can be specified by setting `msg.format`. mp4 video output
-has been tested, but setting `msg.format='mp4'``
+has been tested, by setting `msg.format='mp4'`
 
 Returns a buffer of the converted data on `msg.payload`.
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,13 @@ Should support any audio or video input currently supported by FFmpeg. Full list
 
 Supported output formats (audio only):
 
-* MP3 (not supported as input to Watson Speech to Text)
+* MP3
 * WAV
 * FLAC
 * OGG
+
+Additional output formats can be specified by setting `msg.format`. mp4 video output
+has been tested, but setting `msg.format='mp4'``
 
 Returns a buffer of the converted data on `msg.payload`.
 

--- a/ffmpeg-conversion/ffmpeg-conversion.html
+++ b/ffmpeg-conversion/ffmpeg-conversion.html
@@ -50,7 +50,7 @@
 
     <p>Supported output formats (audio only):</p>
     <ul>
-      <li><strong>MP3</strong> (not supported by Watson Speech to Text)</li>
+      <li><strong>MP3</strong></li>
       <li><strong>WAV</strong></li>
       <li><strong>FLAC</strong></li>
       <li><strong>OGG</strong></li>
@@ -67,6 +67,10 @@
       <li><strong>MP4</strong> to <strong>MP3/WAV/FLAC/OGG</strong></li>
       <li><strong>WAV</strong> to <strong>MP3/WAV/FLAC/OGG</strong></li>
     </ul>
+
+    <p>If you want another format then set <code>msg.format</code>. EG.
+    <code>msg.format='mp4'</code>. Some output video formats have been 
+    tested.</p>
 </script>
 
 <script type="text/javascript">

--- a/ffmpeg-conversion/ffmpeg-conversion.js
+++ b/ffmpeg-conversion/ffmpeg-conversion.js
@@ -37,7 +37,7 @@ module.exports = function (RED) {
 
     this.on('input', function (msg) {
       var message;
-      
+
       if (msg.format) {
         config.format = msg.format;
       }
@@ -120,7 +120,8 @@ module.exports = function (RED) {
               text:'converting'});
           };
 
-          var conversionError = function() {
+          var conversionError = function(err) {
+            console.log(err)
             nodeError('ffmpeg conversion failed', 'FFmpeg failed to perform the conversion');
           };
 
@@ -144,6 +145,14 @@ module.exports = function (RED) {
             ffmpeg(pathToFile)
               .format(config.format)
               .noVideo()
+              // If Video is required then this set of 3 options works for MP4
+              // with msg.format ='mp4'
+              // Also doesn't appear to harm audio options so keeping it in
+              // until someone complains.
+              .outputOptions('-c:v libx264')
+              .outputOptions('-pix_fmt yuv420p')
+              .outputOptions('-movflags frag_keyframe+empty_moov')
+              //
               .audioChannels(numChannels)
               .audioFrequency(frequency)
               .on('start', conversionStart)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "node-red-contrib-media-utils",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A collection of Node-RED media nodes that can be used with IBM Watson services",
   "dependencies": {
-    "easy-ffmpeg": "0.0.13",
+    "easy-ffmpeg": "0.0.14",
     "file-type": "^2.7.0",
     "request": "~2.53.0",
     "stream-to-array": "^2.3.0",


### PR DESCRIPTION
Bump easy-ffmpeg dependency. Added in code that would generate video output, but needs msg.format to be set to desired output. 